### PR TITLE
Refactor cookbook to use newer zookeeper & exhibitor cookbooks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,7 +2,7 @@
 driver:
   name: vagrant
   customize:
-    memory: 1024
+    memory: 2048
   # name: ec2
   # tags:
   #   Name: test-et-zookeeper

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,9 @@
 ---
 driver:
-  # name: ec2
   name: vagrant
   customize:
     memory: 1024
+  # name: ec2
   # tags:
   #   Name: test-et-zookeeper
   #   Role: et_zookeeper Testing
@@ -15,8 +15,6 @@ provisioner:
   encrypted_data_bag_secret_key_path: ~/.chef/encrypted_data_bag_secret
   data_bags_path: <%= ENV['CHEF_REPO'] %>/data_bags
   environments_path: <%= ENV['CHEF_REPO'] %>/environments
-  client_rb:
-    environment: '_default'
 
 platforms:
 - name: ubuntu-12.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,7 @@ provisioner:
   environments_path: <%= ENV['CHEF_REPO'] %>/environments
 
 platforms:
-- name: ubuntu-12.04
+- name: ubuntu-14.04
 
 suites:
 - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'exhibitor', github: 'SimpleFinance/chef-exhibitor', ref: '1fc2bae6d0'

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ ensemble.
 
 Include the default recipe in a node’s run list.
 
+If using with the [`apache_storm` cookbook](https://github.com/evertrue/apache_storm-cookbook), also ensure `role[zookeeper]` is included in the run list.
+
 # Attributes
 
 Attributes we override in the two base cookbooks:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # et_zookeeper cookbook
 
 Wrapper cookbook for [SimpleFinance’s](https://github.com/SimpleFinance)
-[zookeeper cookbook](https://github.com/SimpleFinance/chef-zookeeper).
-In addition to using the `zookeeper` cookbook to install Exhibitor and
+[zookeeper](https://github.com/SimpleFinance/chef-zookeeper) & [exhibitor](https://github.com/SimpleFinance/chef-exhibitor) cookbooks.
+
+In addition to using these cookbooks to install Exhibitor and
 Zookeeper, this cookbook sets up and enables [shared configuration using S3
 for Exhibitor](https://github.com/Netflix/exhibitor/wiki/Shared-Configuration),
 allowing Exhibitor to handle any additional configuration of the Zookeeper
@@ -12,49 +13,47 @@ ensemble.
 
 * apt
 * build-essential
-* zookeeper
 * java
+* zookeeper
+* exhibitor
 
 # Usage
 
-Include the default recipe, as well as `role[zookeeper]`, in a node’s run list.
+Include the default recipe in a node’s run list.
 
 # Attributes
 
-Attributes we override in the base zookeeper cookbook:
+Attributes we override in the two base cookbooks:
 
-* `node[:exhibitor][:snapshot_dir]`
-* `node[:exhibitor][:transaction_dir]`
-* `node[:exhibitor][:log_index_dir]`
-* `node[:exhibitor][:opts][:configtype]`
-default[:exhibitor][:opts][:s3credentials]`}/s3.conf"
-* `node['exhibitor']['defaultconfig']['auto_manage_instances']`
-* `node['zookeeper']['mirror']`
+* `node['zookeeper']['config']['dataDir']`
+* `node['zookeeper']['config']['initLimit']`
+* `node['zookeeper']['config']['syncLimit']`
+* `node['zookeeper']['config']['autopurge.snapRetainCount']`
+* `node['zookeeper']['config']['autopurge.purgeInterval']`
+* `node['exhibitor']['version']`
+* `node['exhibitor']['snapshot_dir']`
+* `node['exhibitor']['transaction_dir']`
+* `node['exhibitor']['log_index_dir']`
+* `node['exhibitor']['cli']['configtype']`
 
 Additional attributes provided by this cookbook:
 
-* `node[:exhibitor][:opts][:s3region]` – AWS region used to communicate w/ S3
-* `node[:exhibitor][:opts][:s3config]` – S3 bucket & key name for the shared config file
-* `node['et_exhibitor']['defaultconfig']['zoo_cfg_extra']`
-* `node['java']['jdk_version']`
-* `node[:build_essential][:compiletime]`
-
-# Templates
-
-# s3.conf.erb
-
-Provides for a file to be created on the node containing necessary S3
-credentials for Exhibitor to use.
+* `node['exhibitor']['s3']['access-key-id']` – The IAM access key ID
+* `node['exhibitor']['s3']['access-secret-key']` — The IAM secret access key
+* `node['exhibitor']['cli']['s3region']` – AWS region used to communicate w/ S3
+* `node['exhibitor']['cli']['s3config']` – S3 bucket & key name for the shared config file
+* `node['et_exhibitor']['defaultconfig']['zoo_cfg_extra']` – Additional values used for the initial bootstrap; these are used to seed the S3 config file if it doesn’t already exist
+* `node['java']['jdk_version']` – Which version of Java to install
+* `node[:build_essential][:compiletime]` — Ensure that `build-essential` is installed at compile time; needed for some RubyGems to install properly
 
 # Recipes
 
 ## default
 
-* Sets additional Zookeeper config for Exhibitor to use
-* Ensures the JDK version
-* Stores a file containing necessary S3 credentials on the node itself
-* Links Exhibitor’s init script to Upstart’s jobs directory
-* Enables & (re)starts Exhibitor’s service.
+1. Includes `apt::default` recipe to update apt on Debian systems
+2. Sets additional Zookeeper config for Exhibitor to use
+3. Includes `exhibitor::default`, which itself includes `zookeeper::install`, to install and set up Zookeeper and Exhibitor
+4. Includes `exhibitor::service`, to set up and start the Exhibitor service via `runit`
 
 # Author
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,32 +1,10 @@
-set['exhibitor']['version'] = '1.5.2'
-set['exhibitor']['snapshot_dir'] = '/mnt/zookeeper'
-set['exhibitor']['transaction_dir'] = '/mnt/zookeeper'
-set['exhibitor']['log_index_dir'] = '/mnt/zookeeper_log_indexes'
-
-# Use S3 for Exhibitor's shared configuration
-
-# Load encrypted credentials
-aws_creds = Chef::EncryptedDataBagItem.load('secrets', 'aws_credentials')['ZookeeperS3']
-
-set['exhibitor']['opts']['configtype'] = 's3'
-set['exhibitor']['s3key'] = aws_creds['access_key_id']
-set['exhibitor']['s3secret'] = aws_creds['secret_access_key']
-set['exhibitor']['opts']['s3region'] = 'us-east-1'
-set['exhibitor']['opts']['s3config'] = "ops.evertrue.com:zookeeper-#{node.chef_environment}"
-
-default['et_exhibitor']['defaultconfig']['zoo_cfg_extra'] = {
-  'tickTime' => '2000',
-  'initLimit' => '11',
-  'syncLimit' => '17',
-  'autopurge.snapRetainCount' => '20',
-  'autopurge.purgeInterval' => '1'
-}
-
-set['exhibitor']['defaultconfig']['auto_manage_instances'] = 1
-
 default['java']['jdk_version'] = '7'
 default['build_essential']['compiletime'] = true
 
-set['zookeeper']['version'] = '3.4.6'
-set['zookeeper']['mirror'] = 'http://apache.petsads.us/zookeeper/current/zookeeper-3.4.6.tar.gz'
-set['zookeeper']['checksum'] = '01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994'
+set['zookeeper']['service_style'] = 'exhibitor'
+
+set['zookeeper']['config']['dataDir'] = '/mnt/zookeeper'
+set['zookeeper']['config']['initLimit'] = '11'
+set['zookeeper']['config']['syncLimit'] = '17'
+set['zookeeper']['config']['autopurge.snapRetainCount'] = '20'
+set['zookeeper']['config']['autopurge.purgeInterval'] = '1'

--- a/attributes/exhibitor.rb
+++ b/attributes/exhibitor.rb
@@ -1,0 +1,23 @@
+set['exhibitor']['version'] = '1.5.2'
+set['exhibitor']['snapshot_dir'] = '/mnt/zookeeper'
+set['exhibitor']['transaction_dir'] = '/mnt/zookeeper'
+set['exhibitor']['log_index_dir'] = '/mnt/zookeeper_log_indexes'
+
+# Use S3 for Exhibitor's shared configuration
+
+# Load encrypted credentials
+aws_creds = Chef::EncryptedDataBagItem.load('secrets', 'aws_credentials')['ZookeeperS3']
+
+set['exhibitor']['cli']['configtype'] = 's3'
+set['exhibitor']['s3']['access-key-id'] = aws_creds['access_key_id']
+set['exhibitor']['s3']['access-secret-key'] = aws_creds['secret_access_key']
+set['exhibitor']['cli']['s3region'] = 'us-east-1'
+set['exhibitor']['cli']['s3config'] = "ops.evertrue.com:zookeeper-#{node.chef_environment}"
+
+default['et_exhibitor']['defaultconfig']['zoo_cfg_extra'] = {
+  'tickTime' => '2000',
+  'initLimit' => '11',
+  'syncLimit' => '17',
+  'autopurge.snapRetainCount' => '20',
+  'autopurge.purgeInterval' => '1'
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,5 +9,6 @@ version          '1.2.1'
 
 depends 'apt'
 depends 'build-essential'
-depends 'zookeeper',       '~> 1.4.9'
+depends 'zookeeper',       '~> 2.5'
+depends 'exhibitor'
 depends 'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,23 +7,14 @@
 # All rights reserved - Do Not Redistribute
 #
 
-node.set['exhibitor']['defaultconfig']['zoo_cfg_extra'] =
-  node['et_exhibitor']['defaultconfig']['zoo_cfg_extra']
-  .map { |k, v| "#{k}\\=#{v}" }
-  .join '&'
-
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
 end
 
-include_recipe 'build-essential'
+node.set['exhibitor']['config']['zoo_cfg_extra'] =
+  node['et_exhibitor']['defaultconfig']['zoo_cfg_extra']
+    .map { |k, v| "#{k}\\=#{v}" }.join '&'
 
-include_recipe 'zookeeper'
-
-link '/etc/init.d/exhibitor' do
-  to '/lib/init/upstart-job'
-end
-
-s = resources(service: 'exhibitor')
-s.action [:enable, :start]
+include_recipe 'exhibitor'
+include_recipe 'exhibitor::service'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe 'Exhibitor Service' do
-  describe file '/etc/init.d/exhibitor' do
-    it { should be_linked_to '/lib/init/upstart-job' }
-  end
-
   describe file '/opt/exhibitor/exhibitor.s3.properties' do
     it { should be_file }
     its(:content) { should include 'com.netflix.exhibitor.s3.access-key-id=' }
@@ -21,7 +17,7 @@ describe 'Exhibitor Service' do
     end
   end
 
-  describe file '/etc/init/exhibitor.conf' do
+  describe file '/etc/sv/exhibitor/run' do
     it { should be_file }
     its(:content) { should include '--configtype s3' }
     its(:content) { should include '--s3config ops.evertrue.com:zookeeper-' }
@@ -34,7 +30,6 @@ describe 'Exhibitor Service' do
   end
 
   describe service 'exhibitor' do
-    it { should be_enabled }
     it { should be_running }
   end
 end


### PR DESCRIPTION
Thanks to hard work from the SimpleFinance team, we can now take advantage of two more cleanly separated cookbooks, instead of the tightly-coupled mess that the previous Zookeeper (pre-2.0) cookbook was.

This converges well, and tests well (though tests were modified due to changes in how things are applied), but the encouragement will be to spin up a new cluster, rather than apply this to existing nodes.

The existing clusters’ nodes will need to have their run lists adjusted to pin the recipe’s version so they don’t update to this automatically.