### PR TITLE
Upgrade exhibitor and, by extension, zookeeper dep

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ version          '2.0.1'
 
 depends 'apt'
 depends 'build-essential'
-depends 'exhibitor', '~> 0.5.0'
+depends 'exhibitor', '~> 0.8.0'
 depends 'java'


### PR DESCRIPTION
Effects:

* Fix the issue of the home folder not being present
* Maintain using ZooKeeper v3.4.6, using a supported version of the `zookeeper` cookbook in play

@eherot I definitely want your eyes on the changes here, they’re sizeable.

* [`exhibitor 0.5.0...0.8.0`](https://github.com/SimpleFinance/chef-exhibitor/compare/0.5.0...0.8.0)
* [`zookeeper v2.13.1...v3.1.0`](https://github.com/evertrue/zookeeper-cookbook/compare/v2.13.1...v3.1.0)
    - This version of `zookeeper`, while it has a breaking version number change, does not, in fact, include any breaking changes (the break that v3.0.0 suggests was reverted in v3.0.2, see evertrue/zookeeper-cookbook#159 for details)
    - That said, this _does_ include all of the non-breaking changes and fixes from v3.0.6...v5.0.0, so that’s awesome.